### PR TITLE
getField tentative fix to avoid runtime exception

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -19,7 +19,7 @@ export const getVendorsApi = (
 };
 
 export const getField = (fieldId: string): JQuery<HTMLElement> =>
-  AJS.$(`#${fieldId}`);
+  AJS.$(document.getElementById(fieldId));
 
 const getApiNode = (fieldId: string): JQuery<HTMLElement> => {
   const $field = getField(fieldId);


### PR DESCRIPTION
Having a field ID ending with e.g. :1 can cause an "unsupported pseudo" runtime error if using JQuery directly.